### PR TITLE
Adding wagtail_modeladmin as a dependency

### DIFF
--- a/formation/wagtail_hooks.py
+++ b/formation/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from wagtail import hooks
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
 
 from .models import ReusableForm
 from .views import ReusableFormChooserViewSet

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ wagtail==4.2.1
 Django==4.1.7
 cryptography==39.0.2
 wagtail-generic-chooser==0.5.1
+wagtail_modeladmin==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -14,6 +14,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'cryptography==39.0.0',
     'wagtail-generic-chooser==0.5.1',
+    'wagtail_modeladmin==2.0.0'
 ]
 
 test_requirements = []


### PR DESCRIPTION
Wagtail 6 removed `wagtail.contrib.modeladmin` from the core and it now exists as an [independent package](https://github.com/wagtail-nest/wagtail-modeladmin). This updates the dependencies for Wagtail Formation and rewrites some Model Admin imports.